### PR TITLE
DO NOT MERGE: [add] ImmutableJS support 

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,17 +6,16 @@ module.exports = function(config) {
     frameworks: [ 'mocha', 'sinon-chai' ],
 
     autoWatchBatchDelay: 400,
-    logLevel: config.LOG_ERROR,
 
     files: [
       'src/**/__tests__/*.js*'
     ],
 
     preprocessors: {
-      'src/**/__tests__/*.js*' : [ 'webpack' ]
+      'src/**/__tests__/*.js*' : ['webpack', 'sourcemap']
     },
 
-    reporters: [ 'nyan', 'coverage' ],
+    reporters: [ 'progress', 'coverage' ],
 
     coverageReporter: {
       type: 'html',
@@ -26,7 +25,6 @@ module.exports = function(config) {
 
     webpack: {
       devtool : 'inline-source-map',
-
       module: {
         loaders: [{
           test    : /\.jsx*$/,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel": "~5",
     "babel-loader": "~5",
     "babel-runtime": "~5",
+    "immutable": "^3.7.3",
     "istanbul-instrumenter-loader": "~0.1",
     "karma": "~0.12",
     "karma-cli": "~0.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "karma-coverage": "~0.3",
     "karma-firefox-launcher": "~0.1",
     "karma-mocha": "~0.1",
-    "karma-nyan-reporter": "~0.0",
     "karma-sinon-chai": "~0.3",
+    "karma-sourcemap-loader": "^0.3.4",
     "karma-webpack": "~1.5"
   },
   "dependencies": {

--- a/src/Foliage.js
+++ b/src/Foliage.js
@@ -5,16 +5,18 @@
  * @param {Object} state - The initial state of the instance
  */
 
-let assoc  = require('./assoc')
-let dissoc = require('./dissoc')
-let getIn  = require('./get')
-let Diode  = require('diode')
+let assoc    = require('./assoc')
+let dissoc   = require('./dissoc')
+let getIn    = require('./get')
+let Diode    = require('diode')
+let keysOf   = require('./keys')
+let valuesOf = require('./values')
 
 function Foliage (state) {
   Diode(this)
 
-  this._path  = []
-  this._root  = this
+  this._path = []
+  this._root = this
 
   this.commit(state)
 }
@@ -73,16 +75,11 @@ Foliage.prototype = {
   },
 
   keys() {
-    return Object.keys(this.valueOf() || {})
+    return keysOf(this.valueOf())
   },
 
   values() {
-    // An anonymous function is used here instead of
-    // calling `this.get` directly because we have no
-    // fallback value.
-    return this.keys().map(function(key) {
-      return this.get(key)
-    }, this)
+    return valuesOf(this.valueOf())
   },
 
   valueOf() {

--- a/src/__tests__/assoc.test.js
+++ b/src/__tests__/assoc.test.js
@@ -1,24 +1,75 @@
 import assoc from '../assoc'
+import get   from '../get'
+import Immutable from 'immutable'
 
 describe('assoc', function() {
 
-  it ('makes no change when assigned the same values', function() {
-    let sample = { foo: 'bar' }
-    assoc(sample, [ 'foo' ], 'bar').should.equal(sample)
+  describe('Plain ole\' JavaScript', function() {
+    let subject = { foo: 'bar' }
+
+    it ('makes no change when assigned the same values', function() {
+      assoc(subject, [ 'foo' ], 'bar').should.equal(subject)
+    })
+
+    it ('makes objects non-existant pathways', function() {
+      let output = assoc(subject, [ 'different', 'path' ], 'bar')
+
+      get(output, [ 'different', 'path' ]).should.equal('bar')
+    })
+
+    it ('it properly sets the value when given no pathway', function() {
+      let output = assoc(subject, [], { reset: true})
+      get(output, [ 'reset' ]).should.equal(true)
+    })
   })
 
-  it ('makes objects non-existant pathways', function() {
-    let sample = {}
-    let output = assoc(sample, [ 'foo', 'step' ], 'bar')
+  describe('Immutable.Map', function() {
+    let subject = Immutable.Map({ foo: 'bar' })
 
-    output.foo.step.should.equal('bar')
+    it ('makes no change when assigned the same values', function() {
+      assoc(subject, [ 'foo' ], 'bar').should.equal(subject)
+    })
+
+    it ('makes objects non-existant pathways', function() {
+      let output = assoc(subject, [ 'different', 'path' ], 'bar')
+
+      get(output, [ 'different', 'path' ]).should.equal('bar')
+    })
+
+    it ('it properly sets the value when given no pathway', function() {
+      let output = assoc(subject, [], { reset: true})
+      get(output, [ 'reset' ]).should.equal(true)
+    })
   })
 
-  it ('it properly sets the value when given no pathway', function() {
-    let sample = {}
-    let output = assoc(sample, [], { foo: 'bar' })
+  describe('Immutable.Record', function() {
+    let subject = Immutable.Record({ foo: 'bar' })()
 
-    output.foo.should.equal('bar')
+    it ('makes no change when assigned the same values', function() {
+      assoc(subject, [ 'foo' ], 'bar').should.equal(subject)
+    })
+
+    it ('throws an error on non-existant pathways', function(done) {
+      try {
+        assoc(subject, [ 'different', 'path' ], 'bar')
+      } catch(x) {
+        x.should.be.instanceOf(Error)
+        done()
+      }
+    })
   })
 
+  describe('Immutable.List', function() {
+    let subject = Immutable.List([ 'foo', 'bar' ])
+
+    it ('makes no change when assigned the same values', function() {
+      assoc(subject, [ 0 ], 'foo').should.equal(subject)
+    })
+
+    it ('makes objects non-existant pathways', function() {
+      let output = assoc(subject, [ 2, 'three' ], 'wut')
+
+      get(output, [ 2, 'three' ]).should.equal('wut')
+    })
+  })
 })

--- a/src/__tests__/dissoc.test.js
+++ b/src/__tests__/dissoc.test.js
@@ -1,20 +1,45 @@
-import dissoc from '../dissoc'
+import dissoc   from '../dissoc'
+import get       from '../get'
+import Immutable from 'immutable'
 
 describe('dissoc', function() {
 
-  it ('does not modify missing keys', function() {
+  describe('Plain ole\' JavaScript', function() {
     let sample = { foo: 'bar' }
-    dissoc(sample, [ 'missing' ]).should.equal(sample)
+
+    it ('does not modify missing keys', function() {
+      dissoc(sample, [ 'missing' ]).should.equal(sample)
+    })
+
+    it ('removes properties', function() {
+      dissoc(sample, [ 'foo' ]).should.eql({})
+    })
+
+    it ('prunes empty objects', function() {
+      dissoc({ one: { two: 'three' } }, [ 'one', 'two' ]).should.eql({})
+    })
   })
 
-  it ('removes properties', function() {
-    let sample = { foo: 'bar' }
-    dissoc(sample, [ 'foo' ]).should.eql({})
+  describe('Immutable.Map', function() {
+    let sample = Immutable.Map({ foo: 'bar' })
+
+    it ('does not modify missing keys', function() {
+      dissoc(sample, [ 'missing' ]).should.equal(sample)
+    })
+
+    it ('removes properties', function() {
+      let next = dissoc(sample, [ 'foo' ])
+      next.size.should.equal(0)
+    })
   })
 
-  it ('prunes empty objects', function() {
-    let sample = { one: { two: 'three' } }
-    dissoc(sample, [ 'one', 'two' ]).should.eql({})
+  describe('Immutable.List', function() {
+    let sample = Immutable.List([ 'one', 'two'])
+
+    it ('does not modify missing keys', function() {
+      let next = dissoc(sample, [ 0 ])
+      next.get(0).should.equal('two')
+    })
   })
 
 })

--- a/src/__tests__/enumeration.test.js
+++ b/src/__tests__/enumeration.test.js
@@ -1,8 +1,12 @@
-import Foliage from '../Foliage'
+import Foliage   from '../Foliage'
+import Immutable from 'immutable'
 
-describe('Foliage', function() {
+describe('Enumeration', function() {
+
   let array = [1, 2, 3, 4 ]
   let object = { a: 1, b: 2, c: 3, d: 4 }
+  let map = Immutable.Map(object)
+  let list = Immutable.Set(array)
 
   let tests = new Foliage([
     [ 'map',    (i => i + 1) ],
@@ -31,6 +35,20 @@ describe('Foliage', function() {
         plant[method](...args).should.eql(expected)
       })
 
+      it ('works at the root level with maps', function() {
+        let plant    = new Foliage(map)
+        let expected = plant.values()[method](...args)
+
+        plant[method](...args).should.eql(expected)
+      })
+
+      it ('works at the root level with sets', function() {
+        let plant    = new Foliage(map)
+        let expected = plant.values()[method](...args)
+
+        plant[method](...args).should.eql(expected)
+      })
+
       it ('works at a sub-level with arrays', function() {
         let plant    = new Foliage({ body: array })
         let query    = plant.refine('body')
@@ -41,6 +59,22 @@ describe('Foliage', function() {
 
       it ('works at a sub-level level with objects', function() {
         let plant    = new Foliage({ body : object })
+        let query    = plant.refine('body')
+        let expected = query.values()[method](...args)
+
+        query[method](...args).should.eql(expected)
+      })
+
+      it ('works at a sub-level with sets', function() {
+        let plant    = new Foliage({ body: set })
+        let query    = plant.refine('body')
+        let expected = array[method](...args)
+
+        query[method](...args).should.eql(expected)
+      })
+
+      it ('works at a sub-level level with maps', function() {
+        let plant    = new Foliage({ body : map })
         let query    = plant.refine('body')
         let expected = query.values()[method](...args)
 

--- a/src/__tests__/isImmutable.test.js
+++ b/src/__tests__/isImmutable.test.js
@@ -1,0 +1,20 @@
+import isImmutable from '../isImmutable'
+import { Map, List, Record, Set, Stack, Range, Repeat, Seq, Iterable } from 'immutable'
+
+describe('isImmutable', function() {
+  const YES = [ Map, List, Record({}), Set, Stack, Range, Repeat, Seq, Iterable ]
+  const NO  = [ {}, [], true, false, 'string', undefined, null]
+
+  NO.forEach(function(value) {
+    it (`returns false for ${ value }`, function() {
+      isImmutable(value).should.equal(false)
+    })
+  })
+
+  YES.forEach(function(Struct) {
+    it (`returns true for Immutable ${ Struct.name }`, function() {
+      isImmutable(Struct()).should.equal(true)
+    })
+  })
+
+})

--- a/src/__tests__/keys.test.js
+++ b/src/__tests__/keys.test.js
@@ -1,0 +1,23 @@
+import keys from '../keys'
+import { Map, List } from 'immutable'
+
+describe.only('Keys', function() {
+
+  it ('works for objects', function() {
+    keys({ a: 1, b: 2, c: 3 }).should.eql(['a', 'b', 'c'])
+  })
+
+  it ('works for arrays', function() {
+    keys([ 'a', 'b', 'c' ]).should.eql([ '0', '1', '2' ])
+  })
+
+  it.only ('works for maps', function() {
+    let sample = Map({ a: 1, b: 2, c: 3 })
+    keys(sample).should.eql([ 'a', 'b', 'c'])
+  })
+
+  it ('works for lists', function() {
+    keys(List([1, 2, 3])).should.eql([0, 1, 2])
+  })
+
+})

--- a/src/__tests__/values.test.js
+++ b/src/__tests__/values.test.js
@@ -1,0 +1,23 @@
+import values from '../values'
+import { Map, Set } from 'immutable'
+
+describe('Values', function() {
+
+  it ('works for objects', function() {
+    values({ a: 1, b: 2, c: 3 }).should.eql([1,2,3])
+  })
+
+  it ('works for arrays', function() {
+    values([ 1, 2, 3 ]).should.eql([1,2,3])
+  })
+
+  it ('works for maps', function() {
+    let sample = Map({ a: 1, b: 2, c: 3 })
+    values(sample).should.eql([ 1, 2, 3])
+  })
+
+  it ('works for sets', function() {
+    values(Set([1,2,3])).should.eql([1,2,3])
+  })
+
+})

--- a/src/assoc.js
+++ b/src/assoc.js
@@ -10,8 +10,13 @@
 
 let copy = require('./copy')
 let get  = require('./get')
+let isImmutable = require('./isImmutable')
 
 module.exports = function assoc (obj, keys, value) {
+  if (isImmutable(obj)) {
+    return obj.setIn(keys, value)
+  }
+
   if (get(obj, keys) === value) {
     return obj
   }

--- a/src/dissoc.js
+++ b/src/dissoc.js
@@ -6,10 +6,15 @@
  * @param {Array} keys - A list of string keys
  */
 
-let copy = require('./copy')
-let get  = require('./get')
+let copy        = require('./copy')
+let get         = require('./get')
+let isImmutable = require('./isImmutable')
 
 module.exports = function dissoc (obj, keys) {
+  if (isImmutable(obj)) {
+    return obj.removeIn(keys)
+  }
+
   if (get(obj, keys) === undefined) {
     return obj
   }

--- a/src/get.js
+++ b/src/get.js
@@ -7,12 +7,14 @@
  * @param {any} fallback - If the value is undefined, a fallback
  */
 
+let isImmutable = require('./isImmutable')
+
 function pluck(obj, key) {
   return obj ? obj[key] : undefined
 }
 
 module.exports = function (obj, keys, fallback) {
-  let value = keys.reduce(pluck, obj)
+  let value = isImmutable(obj) ? obj.getIn(keys) : keys.reduce(pluck, obj)
 
   return value === undefined ? fallback : value
 }

--- a/src/isImmutable.js
+++ b/src/isImmutable.js
@@ -1,0 +1,5 @@
+const MAP = '@@__IMMUTABLE_ITERABLE__@@'
+
+module.exports = function(obj) {
+  return !!obj && obj[MAP] === true
+}

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,0 +1,6 @@
+let isImmutable = require('./isImmutable')
+
+module.exports = function(obj) {
+  return isImmutable(obj) ? obj.map((value, key) => key).toArray()
+                          : Object.keys(obj || {})
+}

--- a/src/values.js
+++ b/src/values.js
@@ -1,0 +1,9 @@
+let get         = require('./get')
+let isImmutable = require('./isImmutable')
+let keys        = require('./keys')
+
+module.exports = function(obj) {
+  // An anonymous function is used here instead of calling
+  // `get` directly because there is no fallback value.
+  return keys(obj).map(key => get(obj, [ key ]))
+}


### PR DESCRIPTION
I'd like tighter integration with ImmutableJS. Right now, this uses hooks into Immutable itself. Ideally, I'd also like to cover native ES6 Map and Set. Baby steps...

Shockingly, this only adds 80 bytes to the build
